### PR TITLE
Phase 4: LiveData to StateFlow migration

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -4,8 +4,8 @@
 
 - [x] **Phase 1:** Build System Foundation
 - [x] **Phase 2:** KAPT to KSP Migration
-- [ ] **Phase 3:** Kotlin 2.0 Upgrade
-- [ ] **Phase 4:** LiveData to StateFlow Migration
+- [x] **Phase 3:** Kotlin 2.0 Upgrade
+- [x] **Phase 4:** LiveData to StateFlow Migration
 - [ ] **Phase 5:** Jetpack Compose Setup
 - [ ] **Phase 6:** Compose UI Migration
 - [ ] **Phase 7:** Navigation 3 Migration
@@ -15,16 +15,16 @@
 
 ## Target State
 
-| Component | Before | After |
-|-----------|--------|-------|
-| Gradle/AGP | 8.0.0-rc01 | 8.7+ |
-| Kotlin | 1.8.10 | 2.0+ |
-| SDK | 33 | 35 |
-| Annotation Processing | KAPT | KSP |
-| Dependency Management | build.gradle | Version Catalogs |
+| Component | Before | After | Status |
+|-----------|--------|-------|--------|
+| Gradle/AGP | 8.0.0-rc01 | 8.7+ | Done |
+| Kotlin | 1.8.10 | 2.0+ | Done (2.0.21) |
+| SDK | 33 | 35 | Done |
+| Annotation Processing | KAPT | KSP | Done |
+| Dependency Management | build.gradle | Version Catalogs | Done |
 | UI | XML + View Binding | Jetpack Compose |
 | Navigation | Navigation 2.5.3 | Navigation 3 |
-| State Management | LiveData | StateFlow |
+| State Management | LiveData | StateFlow | Done |
 | Image Loading | Glide | Coil |
 | Material Design | Material 2 | Material 3 |
 
@@ -60,6 +60,8 @@ Replace KAPT with KSP for faster builds and better Kotlin support.
 
 Upgrade to Kotlin 2.0+ and add serialization support for Navigation 3.
 
+**Status:** Already complete - Project is on Kotlin 2.0.21 with KSP 2.0.21-1.0.28 and Kotlin Serialization configured.
+
 **Changes:**
 - Upgrade Kotlin to 2.0+
 - Add Kotlin Serialization plugin
@@ -71,13 +73,15 @@ Upgrade to Kotlin 2.0+ and add serialization support for Navigation 3.
 
 Modernize state management in all ViewModels.
 
+**Status:** Complete - All 4 ViewModels migrated to MutableStateFlow/StateFlow, all Fragment/Activity observers updated to repeatOnLifecycle + collect, tests migrated to Turbine, arch-core-testing removed.
+
 **Changes:**
 - Migrate `CatalogViewModel` to StateFlow
 - Migrate `EpisodesViewModel` to StateFlow
 - Migrate `EpisodeDetailsViewModel` to StateFlow
 - Migrate `MainViewModel` to StateFlow
-- Update all Fragment observers to use `collectAsStateWithLifecycle`
-- Update ViewModel tests
+- Update all Fragment/Activity observers to use `repeatOnLifecycle` + `collect`
+- Update ViewModel tests to Turbine
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,8 +122,8 @@ dependencies {
     testImplementation(libs.mockito)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.mockwebserver)
-    testImplementation(libs.arch.core.testing)
     testImplementation(libs.coroutines.test)
+    testImplementation(libs.turbine)
 
     // Core android test libraries
     androidTestImplementation(libs.androidx.test.ext)

--- a/app/src/main/java/org/sslabs/tvmaze/ui/episodedetails/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/org/sslabs/tvmaze/ui/episodedetails/EpisodeDetailsFragment.kt
@@ -50,7 +50,7 @@ class EpisodeDetailsFragment : BaseFragment() {
     private fun init() {
         initMenu()
         uiCommunicationListener.setToolbarExpanded(true)
-        viewModel.state.value?.let { episode ->
+        viewModel.state.value.let { episode ->
             uiCommunicationListener.setToolbarTitle(
                 getString(R.string.episode_toolbar_title, episode.season, episode.number)
             )

--- a/app/src/main/java/org/sslabs/tvmaze/ui/episodedetails/EpisodeDetailsViewModel.kt
+++ b/app/src/main/java/org/sslabs/tvmaze/ui/episodedetails/EpisodeDetailsViewModel.kt
@@ -1,10 +1,11 @@
 package org.sslabs.tvmaze.ui.episodedetails
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.sslabs.tvmaze.data.model.Episode
 import javax.inject.Inject
 
@@ -13,10 +14,9 @@ class EpisodeDetailsViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ViewModel() {
 
-    private val _state: MutableLiveData<Episode> = MutableLiveData(
+    private val _state: MutableStateFlow<Episode> = MutableStateFlow(
         EpisodeDetailsFragmentArgs.fromSavedStateHandle(savedState).episode
     )
 
-    val state: LiveData<Episode>
-        get() = _state
+    val state: StateFlow<Episode> = _state.asStateFlow()
 }

--- a/app/src/main/java/org/sslabs/tvmaze/ui/showdetails/ShowDetailsFragment.kt
+++ b/app/src/main/java/org/sslabs/tvmaze/ui/showdetails/ShowDetailsFragment.kt
@@ -57,28 +57,28 @@ class ShowDetailsFragment : BaseFragment() {
 
     private fun initToolbar() {
         uiCommunicationListener.setToolbarExpanded(true)
-        uiCommunicationListener.setToolbarTitle(viewModel.state.value?.show?.name)
+        uiCommunicationListener.setToolbarTitle(viewModel.state.value.show.name)
     }
 
     private fun initPoster() {
         binding.itemShowPoster.let {
             Glide.with(it)
                 .setDefaultRequestOptions(glideRequestOptions)
-                .load(viewModel.state.value?.show?.image)
+                .load(viewModel.state.value.show.image)
                 .transition(DrawableTransitionOptions.withCrossFade())
                 .into(it)
         }
     }
 
     private fun initSchedule() {
-        viewModel.state.value?.let { state ->
+        viewModel.state.value.let { state ->
             binding.showDetailsAirsOn.showScheduleTimeTv.text = state.show.time
             binding.showDetailsAirsOn.airsDaysList.text = state.show.days?.joinToString("\n")
         }
     }
 
     private fun initGenres() {
-        viewModel.state.value?.show?.genres?.forEach { genre ->
+        viewModel.state.value.show.genres?.forEach { genre ->
             val chip = Chip(context).apply {
                 id = View.generateViewId()
                 text = genre
@@ -92,7 +92,7 @@ class ShowDetailsFragment : BaseFragment() {
     }
 
     private fun initSummary() {
-        viewModel.state.value?.let { state ->
+        viewModel.state.value.let { state ->
             state.show.summary?.let {
                 binding.showDetailsSummary.text =
                     Html.fromHtml(it, Html.FROM_HTML_MODE_COMPACT)


### PR DESCRIPTION
## Summary

- **Migrate all ViewModels from LiveData to StateFlow**: Replace `MutableLiveData`/`LiveData` with `MutableStateFlow`/`StateFlow` across `MainViewModel`, `CatalogViewModel`, `EpisodesViewModel`, `ShowDetailsViewModel`, and `EpisodeDetailsViewModel`
- **Update Fragment observers**: Replace `observe()` calls with `collectLatestLifecycleFlow` using `repeatOnLifecycle` for lifecycle-aware coroutine collection
- **Update tests**: Migrate ViewModel tests from LiveData assertions to StateFlow/Turbine-based assertions
- **Update migration plan**: Mark Phase 4 as complete

## Commits

1. `7617589` Migrate LiveData to StateFlow across all ViewModels
2. `d022931` Update migration plan: mark Phase 4 as complete

## Test plan

- [ ] Run unit tests with `./gradlew test` — all ViewModel tests pass with StateFlow assertions
- [ ] Verify catalog search and pagination work end-to-end
- [ ] Verify show details and episode details screens load correctly
- [ ] Confirm no LiveData imports remain in ViewModel or Fragment files

> **Note**: This is PR 2 of 2, chained on [PR #3](https://github.com/sslabs/tvmaze/pull/3) (Phases 1-3). Merge PR #3 first, then this PR targets `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)