### PR TITLE
Phase 5: Jetpack Compose setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.navigation.safeargs)
@@ -51,6 +52,7 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = true
+        compose = true
     }
 }
 
@@ -116,6 +118,18 @@ dependencies {
     // Glide (will be replaced by Coil later)
     implementation(libs.glide)
     ksp(libs.glide.compiler)
+
+    // Compose
+    implementation(platform(libs.compose.bom))
+    implementation(libs.bundles.compose)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.hilt.navigation.compose)
+    debugImplementation(libs.bundles.compose.debug)
+
+    // Coil for Compose image loading
+    implementation(libs.coil.compose)
 
     // Core unit test libraries
     testImplementation(libs.junit)

--- a/app/src/main/java/org/sslabs/tvmaze/ui/theme/Color.kt
+++ b/app/src/main/java/org/sslabs/tvmaze/ui/theme/Color.kt
@@ -1,0 +1,15 @@
+package org.sslabs.tvmaze.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Light theme colors
+val BlueGrey500 = Color(0xFF607D8B)
+val BlueGrey700 = Color(0xFF455A64)
+val BlueGrey100 = Color(0xFFCFD8DC)
+val Grey400 = Color(0xFFBDBDBD)
+val Grey500 = Color(0xFF9E9E9E)
+
+// Dark theme colors
+val Purple200 = Color(0xFFBB86FC)
+val Purple700 = Color(0xFF3700B3)
+val Teal200 = Color(0xFF03DAC5)

--- a/app/src/main/java/org/sslabs/tvmaze/ui/theme/Theme.kt
+++ b/app/src/main/java/org/sslabs/tvmaze/ui/theme/Theme.kt
@@ -1,0 +1,51 @@
+package org.sslabs.tvmaze.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+
+private val LightColorScheme = lightColorScheme(
+    primary = BlueGrey500,
+    onPrimary = Color.White,
+    primaryContainer = BlueGrey700,
+    secondary = Grey400,
+    secondaryContainer = Grey500,
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple200,
+    onPrimary = Color.Black,
+    primaryContainer = Purple700,
+    secondary = Teal200,
+    secondaryContainer = Teal200,
+)
+
+@Composable
+fun TVmazeTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context)
+            else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/org/sslabs/tvmaze/ui/theme/Typography.kt
+++ b/app/src/main/java/org/sslabs/tvmaze/ui/theme/Typography.kt
@@ -1,0 +1,5 @@
+package org.sslabs.tvmaze.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()  // Use M3 defaults


### PR DESCRIPTION
## Summary

- Add Jetpack Compose infrastructure alongside existing Views (non-destructive)
- Enable Kotlin Compose plugin and `compose = true` buildFeature in app build config
- Add Compose dependencies via BOM (core UI, activity-compose, lifecycle-compose, hilt-navigation-compose, Coil for image loading)
- Create Material 3 theme files mapping existing XML colors to Compose color scheme

## Files Changed

| File | Change |
|------|--------|
| `app/build.gradle.kts` | Added kotlin-compose plugin, enabled compose buildFeature, added dependencies |
| `ui/theme/Color.kt` | Material 3 color definitions (light/dark) |
| `ui/theme/Typography.kt` | Material 3 typography defaults |
| `ui/theme/Theme.kt` | `TVmazeTheme()` composable with dynamic color support |

## Test plan

- [x] `./gradlew assembleDebug` compiles successfully
- [ ] App launches and existing XML-based UI works unchanged
- [ ] Gradle sync resolves all Compose dependencies via BOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)